### PR TITLE
API routes for the search functionalities

### DIFF
--- a/server/rest-api/routes/provinceRoutes.js
+++ b/server/rest-api/routes/provinceRoutes.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { getAllProvinces, getProvinceById } = require("../services/dal-service/data-service/ProvinceDAL");
+const { getAllProvinces, getProvinceById, getProvincesByName, getProvincesByLanguage } = require("../services/dal-service/data-service/ProvinceDAL");
 const { getEthnicGroupsByProvinceId } = require("../services/dal-service/data-service/EthnicGroupDAL");
 const { getLanguagesByProvinceId } = require("../services/dal-service/data-service/LanguageDAL");
 
@@ -53,5 +53,73 @@ router.get('/province/:id', async (req, res) => {
         res.status(500).json({ error: error.message });
     }
 });
+
+router.get('/search/province', async (req, res) => {
+    try {
+        if (!req.query.name) {
+            return res.status(400).json({ 
+                error: 'Province name is required as a query parameter' 
+            });
+        }
+
+        const namePattern = `%${req.query.name}%`;
+        const provinces = await getProvincesByName(namePattern);
+        const formattedResponse = {
+            searchTerm: req.query.name,
+            provinces: await Promise.all(provinces.map(async (province) => {
+                const ethnicGroups = await getEthnicGroupsByProvinceId(province.id);
+                const languages = await getLanguagesByProvinceId(province.id);
+                return {
+                    id: province.id,
+                    name: province.name,
+                    history: province.history,
+                    ethnicGroups: ethnicGroups.map(eg => eg.name),
+                    languages: languages.map(lang => lang.name)
+                };
+            }))
+        };
+        
+        res.json(formattedResponse);
+    } catch (error) {
+        console.error('Route error: search provinces by name:', error);
+        res.status(500).json({ 
+            message: 'Internal server error while searching provinces' 
+        });
+    }
+});
+
+router.get('/search/language', async (req, res) => {
+    try {
+        if (!req.query.name) {
+            return res.status(400).json({ 
+                error: 'Language name is required as a query parameter' 
+            });
+        }
+
+        const provinces = await getProvincesByLanguage(req.query.name);
+        const formattedResponse = {
+            searchTerm: req.query.name,
+            provinces: await Promise.all(provinces.map(async (province) => {
+                const ethnicGroups = await getEthnicGroupsByProvinceId(province.id);
+                const languages = await getLanguagesByProvinceId(province.id);
+                return {
+                    id: province.id,
+                    name: province.name,
+                    history: province.history,
+                    ethnicGroups: ethnicGroups.map(eg => eg.name),
+                    languages: languages.map(lang => lang.name)
+                };
+            }))
+        };
+        
+        res.json(formattedResponse);
+    } catch (error) {
+        console.error('Route error: search provinces by language:', error);
+        res.status(500).json({ 
+            message: 'Internal server error while searching provinces by language' 
+        });
+    }
+});
+
 
 module.exports = router;

--- a/server/rest-api/services/dal-service/data-service/ProvinceDAL.js
+++ b/server/rest-api/services/dal-service/data-service/ProvinceDAL.js
@@ -35,7 +35,8 @@ const PROVINCE_QUERIES = {
         SELECT p.id, p.name, p.history
         FROM provinces p
         JOIN province_languages pl ON p.id = pl.province_id
-        WHERE pl.language_id = $1
+        JOIN languages l ON pl.language_id = l.id
+        WHERE LOWER(l.name) = LOWER($1)
         ORDER BY p.name ASC
     `
 };
@@ -85,16 +86,16 @@ async function getProvincesByName(namePattern) {
 }
 
 /**
- * Retrieve provinces by language ID
- * @param {number} languageId - ID of the language to find provinces for
+ * Retrieve provinces by language name
+ * @param {string} languageName - Name of the language to find provinces for
  * @returns {Promise<Province[]>} Array of Province objects where the language is spoken
  */
-async function getProvincesByLanguage(languageId) {
+async function getProvincesByLanguage(languageName) {
     try {
-        const result = await query(PROVINCE_QUERIES.GET_BY_LANGUAGE, [languageId]);
+        const result = await query(PROVINCE_QUERIES.GET_BY_LANGUAGE, [languageName]);
         return result.rows.map(row => new Province(row));
     } catch (error) {
-        console.error(`Error retrieving provinces for language ID ${languageId}:`, error);
+        console.error(`Error retrieving provinces for language '${languageName}':`, error);
         throw error;
     }
 }

--- a/server/rest-api/services/dal-service/test/Province.test.js
+++ b/server/rest-api/services/dal-service/test/Province.test.js
@@ -105,11 +105,11 @@ describe('Province Service', function() {
   // Test getProvincesByLanguage
   describe('getProvincesByLanguage()', function() {
     it('should retrieve provinces where a specific language is spoken', async function() {
-      // Using language ID 1 (Ilocano, which should exist in multiple provinces)
-      const languageId = 1;
+      // Using a common language in the region (Ilocano)
+      const languageName = 'Ilocano';
       
       // Execute the function under test
-      const provinces = await ProvinceService.getProvincesByLanguage(languageId);
+      const provinces = await ProvinceService.getProvincesByLanguage(languageName);
       
       // Verify results
       expect(Array.isArray(provinces)).toBe(true);
@@ -121,12 +121,12 @@ describe('Province Service', function() {
       });
     });
     
-    it('should return an empty array for non-existent language ID', async function() {
-      // Setup with a language ID that shouldn't exist
-      const nonExistentLanguageId = 999;
+    it('should return an empty array for non-existent language', async function() {
+      // Setup with a language that shouldn't exist
+      const nonExistentLanguage = 'NonExistentLanguage';
       
       // Execute the function under test
-      const provinces = await ProvinceService.getProvincesByLanguage(nonExistentLanguageId);
+      const provinces = await ProvinceService.getProvincesByLanguage(nonExistentLanguage);
       
       // Verify results
       expect(Array.isArray(provinces)).toBe(true);

--- a/server/rest-api/services/dal-service/test/Province.test.js
+++ b/server/rest-api/services/dal-service/test/Province.test.js
@@ -68,4 +68,69 @@ describe('Province Service', function() {
       expect(province).toBeNull();
     });
   });
+
+  // Test getProvincesByName
+  describe('getProvincesByName()', function() {
+    it('should retrieve provinces matching a name pattern', async function() {
+      // Assuming there's a province with "Mountain" in the name
+      const namePattern = '%Mountain%';
+      
+      // Execute the function under test
+      const provinces = await ProvinceService.getProvincesByName(namePattern);
+      
+      // Verify results
+      expect(Array.isArray(provinces)).toBe(true);
+      expect(provinces.length).toBeGreaterThan(0);
+      
+      // Check that all returned provinces match the pattern
+      provinces.forEach(province => {
+        expect(province.name.toLowerCase()).toContain('mountain');
+        verifyProvinceStructure(province);
+      });
+    });
+    
+    it('should return an empty array for non-matching name patterns', async function() {
+      // Setup with a name that shouldn't exist
+      const nonExistentPattern = '%NonExistentProvinceName%';
+      
+      // Execute the function under test
+      const provinces = await ProvinceService.getProvincesByName(nonExistentPattern);
+      
+      // Verify results
+      expect(Array.isArray(provinces)).toBe(true);
+      expect(provinces.length).toBe(0);
+    });
+  });
+  
+  // Test getProvincesByLanguage
+  describe('getProvincesByLanguage()', function() {
+    it('should retrieve provinces where a specific language is spoken', async function() {
+      // Using language ID 1 (Ilocano, which should exist in multiple provinces)
+      const languageId = 1;
+      
+      // Execute the function under test
+      const provinces = await ProvinceService.getProvincesByLanguage(languageId);
+      
+      // Verify results
+      expect(Array.isArray(provinces)).toBe(true);
+      expect(provinces.length).toBeGreaterThan(0);
+      
+      // Verify structure of returned provinces
+      provinces.forEach(province => {
+        verifyProvinceStructure(province);
+      });
+    });
+    
+    it('should return an empty array for non-existent language ID', async function() {
+      // Setup with a language ID that shouldn't exist
+      const nonExistentLanguageId = 999;
+      
+      // Execute the function under test
+      const provinces = await ProvinceService.getProvincesByLanguage(nonExistentLanguageId);
+      
+      // Verify results
+      expect(Array.isArray(provinces)).toBe(true);
+      expect(provinces.length).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
Add language and province search route and standardized the response json format.

Testing in Postman

Province Search
Method: GET
URL: http://localhost:3000/provinces/search/province?name=ben
Query Parameters:
Key: name
Value: ben (or any province name pattern)

Language Search
Method: GET
URL: http://localhost:3000/provinces/search/language?name=Ilocano
Query Parameters:
Key: name
Value: Ilocano (or any language name)

